### PR TITLE
Create a private room per client

### DIFF
--- a/apps/cards_web/assets/js/modules/card_manager.js
+++ b/apps/cards_web/assets/js/modules/card_manager.js
@@ -26,22 +26,34 @@ export default class CardManager {
 
 
   addEventListeners () {
+    var inAnimationClass    = "animated fadeIn",
+        outAnimationClass   = "animated fadeOut",
+        shakeAnimationClass = "animated rubberBand";
+
     this.channel.on("new-card", payload => {
       var $card = $(`[data-card-id='${payload.id}']`);
-      var $cardContainer = $card.parent(".c-card");
 
-      $cardContainer.addClass("animated fadeOut");
-
-      $cardContainer.one("webkitAnimationEnd", () => {
+      $card.addClass(outAnimationClass).one("webkitAnimationEnd", () => {
         $card.html(payload.card);
-        $cardContainer.css("opacity", 0.9);
-        $cardContainer.removeClass("animated fadeOut");
-        $cardContainer.addClass("animated fadeIn");
+
+        $card
+          .css("opacity", 0.95)
+          .removeClass(outAnimationClass)
+          .addClass(inAnimationClass)
+          .one("webkitAnimationEnd", () => $card.removeClass(inAnimationClass));
       });
     });
 
     this.channel.on("reload", payload => {
       window.reload();
+    });
+
+    this.channel.on("shake", payload => {
+      var $card = $(`[data-card-id='${payload.id}']`);
+
+      $card.addClass(shakeAnimationClass).css("z-index", 99999).one("webkitAnimationEnd", () => {
+        $card.removeClass(shakeAnimationClass).css("z-index", 1);
+      });
     });
   }
 

--- a/apps/cards_web/assets/js/modules/card_manager.js
+++ b/apps/cards_web/assets/js/modules/card_manager.js
@@ -17,7 +17,7 @@ export default class CardManager {
 
 
   joinChannel () {
-    this.channel = this.socket.channel("cards:lobby", {});
+    this.channel = this.socket.channel(`cards:${Date.now()}`, {});
 
     this.channel.join()
       .receive("ok", resp => console.log("Joined successfully", resp))

--- a/apps/cards_web/lib/cards_web/channels/cards_channel.ex
+++ b/apps/cards_web/lib/cards_web/channels/cards_channel.ex
@@ -1,7 +1,7 @@
 defmodule Cards.Web.CardsChannel do
   use Phoenix.Channel
 
-  def join("cards:lobby", _message, socket) do
+  def join("cards:" <> _id, _message, socket) do
     {:ok, socket}
   end
 


### PR DESCRIPTION
Until now, all clients connecting to `cards` (even just two windows in the same browser) have been sharing the same room `cards:lobby`, in the `CardsChannel`. 

This would cause the "ask and get" card events to be sent to all the connected clients, causing a bit of trouble on the RPi.

This PR is to ensure that every client creates its own private room at connection time, using a simple `Date.now()` call, in the JS code.