### PR TITLE
Organise secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /deps
 erl_crash.dump
 *.ez
+**/*.secret.*

--- a/apps/cards/config/config.exs
+++ b/apps/cards/config/config.exs
@@ -9,3 +9,10 @@ config :cards, Cards.Dribbble.Client,
   api_key: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
 import_config "#{Mix.env}.exs"
+
+# As a safer alternative, create a #{Mix.env}.secret.exs file, and set your config
+# in there (copy the config above and edit the values). That path is
+# gitignored, so it'll never end up being pushed to origin
+if __DIR__ |> Path.join("#{Mix.env}.secret.exs") |> File.exists? do
+  import_config "#{Mix.env}.secret.exs"
+end

--- a/apps/cards/config/config.exs
+++ b/apps/cards/config/config.exs
@@ -4,6 +4,8 @@ config :cards,
   quotes_api: Cards.Quote.Client,
   hacker_news_api: Cards.HackerNews.Client,
   dribbble_api: Cards.Dribbble.Client,
-  dribbble_api_key: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+config :cards, Cards.Dribbble.Client,
+  api_key: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
 import_config "#{Mix.env}.exs"

--- a/apps/cards/lib/cards/dribbble/client.ex
+++ b/apps/cards/lib/cards/dribbble/client.ex
@@ -18,7 +18,7 @@ defmodule Cards.Dribbble.Client do
     %{title: title, image: image}
 
   def api_url do
-    api_key = Application.get_env(:cards, :dribbble_api_key)
+    [api_key: api_key] = Application.get_env(:cards, __MODULE__)
     "https://api.dribbble.com/v1/shots?sort=views&access_token=#{api_key}"
   end
 end


### PR DESCRIPTION
Hopefully these changes are clear enough! 😀 

It's a pretty widespread convention in Elixir to attach config keys to modules whenever they relate to just one module. In this case...
```
dribbble_api_key: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" 
```
is only used in the `Cards.Dribbble.Client` module, so we move its config under a separate key of the `:cards` config:
```
config :cards, Cards.Dribbble.Client,
  api_key: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
```

Ping me for the dribbble key!